### PR TITLE
Archive lab

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,7 +12,7 @@ repository:
   has_issues: true
   has_projects: false
   has_wiki: false
-  archived: false
+  archived: true
   private: false
   allow_squash_merge: true
   allow_merge_commit: false


### PR DESCRIPTION
Archived labs are read-only, and they can be moved back out of the archives, if there is interest in reviving them.

Signed-off-by: Ry Jones <ry@linux.com>